### PR TITLE
✏Fix subreddit sampler link

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -296,7 +296,7 @@
         <div class="project" id="project--subreddit-sampler">
             <img class="project--screenshot" src="/static/project-screenshots/sampler.png"/>
             <h2>Subreddit Sampler
-              <a href="https:/subreddit-sampler.herokuapp.com">
+              <a href="https://subreddit-sampler.herokuapp.com">
                 <img class="link-arrow" src="/static/icons/right-arrow.svg"/>
               </a>
             </h2>


### PR DESCRIPTION
I wanted to see this neat project but the link was wrong. I took it upon myself to fix it. 

The link was missing a `/` and the href was `https://www.erick.codes/subreddit-sampler.herokuapp.com` instead of `https://subreddit-sampler.herokuapp.com/`

**/youtube toto africa**

[![Toto - Africa (Official Music Video) - YouTube](http://img.youtube.com/vi/FTQbiNvZqaY/0.jpg)](http://www.youtube.com/watch?v=FTQbiNvZqaY "Toto - Africa (Official Music Video) - YouTube")